### PR TITLE
Fix issue blacklisting an immutable displaying a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-storage-decorator-filter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Filter decorator for redux-storage",
   "main": "build/index.js",
   "jsnext:main": "src/index.js",

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -57,7 +57,7 @@ describe('decorator', () => {
         save.should.have.been.calledWith({});
     });
 
-    it('should support immutable', () => {
+    it('should support whitelisting an immutable', () => {
         const save = sinon.spy();
         const engine = filter({ save }, [['some', 'key']]);
 
@@ -129,13 +129,13 @@ describe('decorator', () => {
         save.should.have.been.calledWith({ key: 'value' });
     });
 
-    it('should support immutable', () => {
+    it('should support blacklisting an immutable', () => {
         const save = sinon.spy();
         const engine = filter({ save }, [['some', 'key']], [['some', 'key']]);
 
         engine.save({ some: map({ key: 42 }) });
 
-        save.should.have.been.calledWith({ some: {} });
+        save.should.have.been.calledWith({ some: map({}) });
     });
 
     it('should handle null values (PR #64)', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,13 @@ export default (engine, whitelist = [], blacklist = []) => {
                     key = [key]; // eslint-disable-line no-param-reassign
                 }
 
-                unset(saveState, key);
+                const value = state[key[0]];
+
+                if (value && isFunction(value.deleteIn)) {
+                    saveState[key[0]] = value.deleteIn(key.slice(1));
+                } else {
+                    unset(saveState, key);
+                }
             });
 
             return engine.save(saveState);


### PR DESCRIPTION
When handling an immutable store, blacklisting code is using lodash.unset which calls length property causing a deprecation warning in console (and soon an error). Fixes #15 
