### PR TITLE
Fix incorrect save state when whitelist key path does not exist on state. issue #28

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lodash.get": "^4.1.2",
     "lodash.isfunction": "^3.0.7",
     "lodash.isobject": "^3.0.2",
+    "lodash.reduce": "^4.3.0",
     "lodash.set": "^4.0.0",
     "lodash.unset": "^4.1.0"
   }

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -50,9 +50,9 @@ describe('decorator', () => {
 
     it('should ignore not existing but whitelisted key paths', () => {
         const save = sinon.spy();
-        const engine = filter({ save }, [['some', 'key']]);
+        const engine = filter({ save }, [['a', 'nonExistingProp']]);
 
-        engine.save({ ignored: true });
+        engine.save({ a: { existingProp: true } });
 
         save.should.have.been.calledWith({});
     });


### PR DESCRIPTION
It was possible to have a whitelisted nested path that did not exist in the state. The result was that the property corresponding to the whitelisted key would have a value of the subsection of the parent.

for example if I have whitelisted `[[ 'a': 'someProp' ]]`
and then I save my state which is in the form `{ a: { someOtherProp: true } }`
the result of the loaded state would be `{ a: { someProp: { someOtherProp: true } } }`

I switch to using `lodash.reduce` since this library was already using lodash. The other option would have been to use a for loop and break if there was no property found for the keyPart. 
Using reduce seemed more appropriate since since we are reducing the state to a sub-section that is whitelisted

Fixes #28 
