### PR TITLE
Ability to supply empty array as blacklist

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -201,4 +201,13 @@ describe('decorator', () => {
 
         save.should.have.been.calledWith({ a: map({ }) });
     });
+
+    it('should support empty blacklist', () => {
+        const save = sinon.spy();
+        const engine = filter({ save }, null, []);
+
+        engine.save({ a: { '1': 1, '2': 2 } });
+
+        save.should.have.been.calledWith({ a: { '1': 1, '2': 2 } });
+    });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import isObject from 'lodash.isobject';
 import set from 'lodash.set';
 import unset from 'lodash.unset';
 
-export default (engine, whitelist = [], blacklist = []) => {
+export default (engine, whitelist = null, blacklist = null) => {
     whitelist = whitelist || []; // eslint-disable-line no-param-reassign
 
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,11 @@ export default (engine, whitelist = null, blacklist = null) => {
             let saveState = {};
 
             // Copy the whole state if we're about to blacklist only
-            if (whitelist.length === 0 && blacklist.length > 0) {
+            if (whitelist.length === 0 && blacklist !== null) {
                 saveState = { ...state };
             }
+
+            blacklist = blacklist || []; // eslint-disable-line no-param-reassign
 
             whitelist.forEach((key) => {
                 // Support strings for one-level paths


### PR DESCRIPTION
In reference to the issue #38 

If an empty array is specified as blacklist, the entire state is returned.